### PR TITLE
xmand: xwin: makefiles for aarch64

### DIFF
--- a/xmand/Makefile.deb_aarch64
+++ b/xmand/Makefile.deb_aarch64
@@ -1,0 +1,40 @@
+
+CC=/usr/bin/cc
+
+CFLAGS= -I$(IDIR) -std=iso9899:1999 -march=native \
+	-mtune=cortex-a53 \
+	-mtls-dialect=trad -pedantic -Wl,-rpath=/opt/bw/lib \
+	-mlittle-endian -O2
+
+CPPFLAGS=-D_TS_ERRNO -D_POSIX_PTHREAD_SEMANTICS -D_LARGEFILE64_SOURCE \
+	-D_X_OPEN_SOURCE=600
+
+LIBS = -lX11 -lrt -lm -lpthread
+
+SRCS = ./mandel_col.c \
+	./linear_inter.c \
+	./mbrot.c \
+	../xwin/x_error_handler.c \
+	../xwin/create_gc.c \
+	../xwin/create_borderless_topwin.c \
+	../time_and_date/timediff.c \
+	../pthread/sysmem.c ../pthread/sysinfo.c
+
+
+OBJS = ./mandel_col.o \
+	./linear_inter.o \
+	./mbrot.o \
+	../xwin/x_error_handler.o \
+	../xwin/create_gc.o \
+	../xwin/create_borderless_topwin.o \
+	../time_and_date/timediff.o \
+	../pthread/sysmem.o ../pthread/sysinfo.o
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS) $(CPPFLAGS)
+
+xmand: xmand.o $(OBJS)
+	$(CC) -o $@ $^ $(CFLAGS) $(CPPFLAGS) $(LIBS)
+
+clean:
+	rm -f $(OBJS) xmand.o xmand

--- a/xwin/Makefile.deb_aarch64
+++ b/xwin/Makefile.deb_aarch64
@@ -1,0 +1,85 @@
+
+CC=/usr/bin/cc
+
+CFLAGS= -I$(IDIR) -std=iso9899:1999 -fno-builtin -g -march=native \
+	-mtune=cortex-a53 \
+	-mtls-dialect=trad -pedantic -mlittle-endian
+
+CPPFLAGS=-D_TS_ERRNO -D_POSIX_PTHREAD_SEMANTICS -D_LARGEFILE64_SOURCE \
+	-D_X_OPEN_SOURCE=600
+
+LIBS = -lX11 -lrt -lm
+
+CMPLEX_DIR=../complex_vector
+IDIR=/usr/local/include
+LDIR=/usr/local/lib
+
+SRCS = grid.c x_error_handler.c create_gc.c \
+	create_borderless_topwin.c \
+	../time_and_date/timediff.c \
+	../complex_vector/intercept.c \
+	../complex_vector/intercept_point.c \
+	../complex_vector/gradient.c \
+	../complex_vector/check_status.c \
+	../complex_vector/cplex_add.c \
+	../complex_vector/cplex_check.c \
+	../complex_vector/cplex_div.c \
+	../complex_vector/cplex_mag.c \
+	../complex_vector/cplex_mult.c \
+	../complex_vector/cplex_quad.c \
+	../complex_vector/cplex_sq.c \
+	../complex_vector/cplex_sqrt.c \
+	../complex_vector/cplex_sub.c \
+	../complex_vector/cplex_theta.c \
+	../complex_vector/cplex_vec_add.c \
+	../complex_vector/cplex_vec_copy.c \
+	../complex_vector/cplex_vec_dot.c \
+	../complex_vector/cplex_vec_set.c \
+	../complex_vector/cplex_vec_print.c \
+	../complex_vector/cplex_vec_scale.c \
+	../complex_vector/cplex_vec_mag.c \
+	../complex_vector/cplex_vec_normalize.c \
+	../complex_vector/cplex_vec_cross.c \
+	../complex_vector/cplex_cramer.c \
+	../complex_vector/cplex_det.c \
+	../pthread/sysmem.c ../pthread/sysinfo.c
+
+
+OBJS = x_error_handler.o create_gc.o \
+	create_borderless_topwin.o \
+	../time_and_date/timediff.o \
+	../complex_vector/intercept.o \
+	../complex_vector/intercept_point.o \
+	../complex_vector/gradient.o \
+	../complex_vector/check_status.o \
+	../complex_vector/cplex_add.o \
+	../complex_vector/cplex_check.o \
+	../complex_vector/cplex_div.o \
+	../complex_vector/cplex_mag.o \
+	../complex_vector/cplex_mult.o \
+	../complex_vector/cplex_quad.o \
+	../complex_vector/cplex_sq.o \
+	../complex_vector/cplex_sqrt.o \
+	../complex_vector/cplex_sub.o \
+	../complex_vector/cplex_theta.o \
+	../complex_vector/cplex_vec_add.o \
+	../complex_vector/cplex_vec_copy.o \
+	../complex_vector/cplex_vec_dot.o \
+	../complex_vector/cplex_vec_set.o \
+	../complex_vector/cplex_vec_print.o \
+	../complex_vector/cplex_vec_scale.o \
+	../complex_vector/cplex_vec_mag.o \
+	../complex_vector/cplex_vec_normalize.o \
+	../complex_vector/cplex_vec_cross.o \
+	../complex_vector/cplex_cramer.o \
+	../complex_vector/cplex_det.o \
+	../pthread/sysmem.o ../pthread/sysinfo.o
+
+%.o: %.c
+	$(CC) -c -o $@ $< $(CFLAGS) $(CPPFLAGS) -I$(CMPLEX_DIR) -I$(IDIR)
+
+grid: grid.o $(OBJS)
+	$(CC) -o $@ $^ $(CFLAGS) $(CPPFLAGS) -L$(LDIR) $(LIBS)
+
+clean:
+	rm -f $(OBJS) grid.o grid


### PR DESCRIPTION
Don't really know what I'm doing but it worked on my Odroid C2, which is aarch64 architechture.
21 sec to render!

```
odroid@odroid:~/lastmiles/xmand$ ./xmand 65536 16384000000 -1.985414382868e-01 -1.100137043154
-------------------------------------------------------------
           system name = Linux
             node name = odroid
               release = 3.16.72-46
               version = #1 SMP PREEMPT Tue Aug 13 18:09:58 -03 2019
               machine = aarch64
             page size = 4096
          avail memory = 1811275776
                       = 1768824 kB
                       = 1727 MB
     fp rounding mode is FE_TONEAREST
 sizeof(unsigned long) = 8
-------------------------------------------------------------
INFO : magnify accepted as long long int
INFO : FP Exception raised is FE_INEXACT FE_INEXACT
real : Perfectly safe to ignore FE_INEXACT
INFO : FP Exception raised is FE_INEXACT
imag : Perfectly safe to ignore FE_INEXACT

mand_bail = 65536
translate = ( -1.985414382868e-01 , -1.100137043154e+00 )
  magnify = +1.638400000000e+10


 X11 : default width=1044 height=1044
     : connection number 3
     : screen number 0
     : default depth is 24
     : display seems to be 1920 wide and 1080 high.
     : offset x=20 y=20
Error 15 (BadName (named color or font does not exist)): request 45.0
     : eff_width =  1024    eff_height =  1024

--------------------------------------------
Error 7 (BadFont (invalid Font parameter)): request 56.0
Error 7 (BadFont (invalid Font parameter)): request 56.0
vbox  [ 014 , 004 ]
[mand] =    21652494047 nsec   2.165249e+01 sec

```